### PR TITLE
0206_微修正_アカウント情報変更入力画面

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,30 +4,31 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
       
-      <div class="box-password_rebuild">
-        <%= f.label :current_password, "【必須】現在のパスワード" %>
-        <%= f.password_field :current_password, autocomplete: "current-password" %>
-      </div>
-      <div class="box-email_rebuild">
-        <%= f.label :email, "【任意】eメール" %>
-        <h4>メールアドレスを変更する場合、<br>新しいメールアドレスを入力してください</h4>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-      </div>
-
+    <div class="box-email_rebuild">
+      <%= f.label :email, "eメール" %>
+      <h4>メールアドレスを変更する場合、<br>新しいメールアドレスを入力してください</h4>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+    
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
         <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
       <% end %>
 
-      <div class="box-password_rebuild">
-        <%= f.label :password, "【任意】新パスワード(6文字以上）" %>
-        <h4>パスワード変更不要の場合、空欄にしてください</h4>
-        <%= f.password_field :password, autocomplete: "new-password" %>
-      </div>
+    <div class="box-password_rebuild">
+      <%= f.label :current_password, "現在のパスワード" %>
+      <%= f.password_field :current_password, autocomplete: "current-password" %>
+    </div>
 
-      <div class="box-password_rebuild">
-        <%= f.label :password_confirmation, "【必須】新パスワード（確認）" %><br />
-        <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-      </div>
+    <div class="box-password_rebuild">
+      <%= f.label :password, "新パスワード(6文字以上）" %>
+      <h4>パスワード変更不要の場合、空欄にしてください</h4>
+      <%= f.password_field :password, autocomplete: "new-password" %>
+    </div>
+
+    <div class="box-password_rebuild">
+      <%= f.label :password_confirmation, "新パスワード（確認）" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
 
       <div class="box-login">
         <%= f.submit "変更する" %>


### PR DESCRIPTION
アカウント変更画面の項目を並び替えた
（変更前）
現在のパスワード
eメール
新パスワード
新パスワード（確認）
（変更後）
eメール
現在のパスワード
新パスワード
新パスワード（確認）